### PR TITLE
Compute checksum for files during download

### DIFF
--- a/refdata/error.py
+++ b/refdata/error.py
@@ -17,15 +17,17 @@ class InvalidChecksumError(RefDataError):
     """Error that is raised when the checksum for a downloaded file does not
     match the checksum that is defined in the repository index.
     """
-    def __init__(self, key: str):
+    def __init__(self, key: str, checksum: str):
         """Initialize the error message.
 
         Parameters
         ----------
         key: string
             Unique external key for the dataset that was downloaded.
+        checksum: string
+            Checksum that was computed for the downloaded file.
         """
-        msg = "invaid checksum for downloaded data file of dataset '{}'".format(key)
+        msg = "invaid checksum '{}' for downloaded data file of dataset '{}'".format(checksum, key)
         super(InvalidChecksumError, self).__init__(msg)
 
 

--- a/tests/.files/index.json
+++ b/tests/.files/index.json
@@ -5,7 +5,7 @@
             "name": "Cities in the U.S.",
             "description": "Names of cities in the U.S. from the Encyclopaedia Britannica.",
             "url": "cities.tsv.gz",
-            "checksum": "b5ea2419cc4b029b1b061da14a4fffe2203bce16e95857d97b68d3fa8335f72b",
+            "checksum": "8d4c77b84cbe8c6683bbfa9f58c8268455f820b98289b51955dcef87b1d48d60",
             "compression": "gzip",
             "webpage": "https://www.britannica.com/topic/list-of-cities-and-towns-in-the-United-States-2023068",
             "schema": [


### PR DESCRIPTION
This PR changes how the checksum for downloaded files are computed.

**Previous Behavior**

The checksum was compute for the downloaded file after it was stored on the local file system. This causes issues (in the unit tests) when downloading text files to/from MS Windows.

**New Behavior**

The checksum is computed over the data stream in the response for by the GET request that downloads the data file.